### PR TITLE
Update training scripts to use common model builder

### DIFF
--- a/proc/_test_train_woscale.py
+++ b/proc/_test_train_woscale.py
@@ -17,7 +17,7 @@ import torch
 from torch import nn, optim
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.tensorboard import SummaryWriter
-from torchvision.models import resnet50
+from util.build_model import build_model
 
 # ---------------------------
 # Torch Dataset & Model
@@ -38,18 +38,6 @@ class WaveformDataset(Dataset):
 		x = torch.from_numpy(self.data[idx]).unsqueeze(0)  # (1, H, W)
 		y = torch.tensor(self.labels[idx])
 		return x, y
-
-
-def build_model(input_channels: int = 1) -> nn.Module:
-	"""ResNet‑50 encoder with custom first conv and sigmoid output."""
-	model = resnet50(weights=None)
-	# Adapt first conv layer to 1 channel
-	model.conv1 = nn.Conv2d(
-		input_channels, 64, kernel_size=7, stride=2, padding=3, bias=False
-	)
-	# Replace final FC for binary classification
-	model.fc = nn.Sequential(nn.Flatten(), nn.Linear(2048, 1))
-	return model
 
 
 # ---------------------------

--- a/proc/apply_gradcam.py
+++ b/proc/apply_gradcam.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.nn.functional as F
-from build_model import build_model
+from util.build_model import build_model
 
 
 # Grad-CAM用フック保存用

--- a/proc/train.py
+++ b/proc/train.py
@@ -14,10 +14,10 @@ from pathlib import Path
 
 import numpy as np
 import torch
-from build_model import build_model
 from torch import nn, optim
 from torch.utils.data import DataLoader, Dataset
 from torch.utils.tensorboard import SummaryWriter
+from util.build_model import build_model
 
 # ---------------------------
 # Torch Dataset & Model


### PR DESCRIPTION
## Summary
- import `build_model` from `util.build_model`
- remove the local duplicate in `_test_train_woscale.py`
- use the shared import in training-related scripts

## Testing
- `python -m py_compile proc/_test_train_woscale.py proc/train.py proc/apply_gradcam.py`
- `ruff check proc/_test_train_woscale.py proc/train.py proc/apply_gradcam.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6882c744e94c832b9f22770947252310